### PR TITLE
build: install catch2 and list tests sources

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -12,6 +12,6 @@ jobs:
 #        run: sudo apt update && sudo apt install catch2
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Make
-        run: make update-cmake && make test-run
+      - name: Tests
+        run: make run-test
       - run: echo "Status ${{ job.status }}."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,6 +8,8 @@ jobs:
       - run: echo "Triggered by ${{ github.event_name }} event."
       - run: echo "Running on ${{ runner.os }} server hosted by GitHub"
       - run: echo "Branch ${{ github.ref }} from repository ${{ github.repository }}."
+      - name: install-catch2
+        run: sudo apt update && sudo apt install catch2
       - name: Checkout
         uses: actions/checkout@v4
       - name: Make

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Tests
-        run: make run-test
+        run: make from-0-to-test
       - run: echo "Status ${{ job.status }}."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Make
-        run: make update-cmake && make
+        run: make update-cmake && make test-run
       - run: echo "Status ${{ job.status }}."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,8 +8,8 @@ jobs:
       - run: echo "Triggered by ${{ github.event_name }} event."
       - run: echo "Running on ${{ runner.os }} server hosted by GitHub"
       - run: echo "Branch ${{ github.ref }} from repository ${{ github.repository }}."
-      - name: install-catch2
-        run: sudo apt update && sudo apt install catch2
+#      - name: install-catch2
+#        run: sudo apt update && sudo apt install catch2
       - name: Checkout
         uses: actions/checkout@v4
       - name: Make

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ libbad_zapple
 .vscode
 *.o
 .cache
+lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
+#---------------------------------------------------------------------------------------#
+
 cmake_minimum_required(VERSION 3.15)
 
 project(libbad_zapple)
+
+#---------------------------------------------------------------------------------------#
+
+set(CUSTOM_LIB_PATH $ENV{HOME}/lib/)
+
+#---------------------------------------------------------------------------------------#
+
+# Build bad-zapple lib
 
 if (NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     message(STATUS "This project has a top-level one called [${CMAKE_PROJECT_NAME}]")
@@ -8,10 +18,39 @@ else()
     message(STATUS "This project is a top-level one")
 endif()
 
-include(build/sources.cmake)
+include(build/lib_sources.cmake)
 
 set (INC inc)
 
 add_library(bad-zapple ${SOURCES})
 
 target_include_directories(bad-zapple PUBLIC ${INC})
+
+#---------------------------------------------------------------------------------------#
+
+# Install Catch2
+set(CMAKE_PREFIX_PATH ${CUSTOM_LIB_PATH}/lib/cmake/Catch2 ${CMAKE_PREFIX_PATH})
+find_package(Catch2 QUIET)
+if (NOT Ccatch2_FOUND)
+	message(STATUS "YourLibrary not found. Attempting to install...")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan "Running installation script..."
+	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_catch.sh
+        RESULT_VARIABLE install_result
+    )
+    if(NOT install_result EQUAL 0)
+        message(FATAL_ERROR "Failed to install YourLibrary. Please install it manually.")
+    endif()
+endif()
+
+#---------------------------------------------------------------------------------------#
+
+# Use the library in the test project
+
+find_package(Catch2 REQUIRED)
+include(build/tests_sources.cmake)
+add_executable(tests ${TEST_SOURCES})
+target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(tests PUBLIC bad-zapple)
+
+#---------------------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,35 +22,36 @@ include(build/lib_sources.cmake)
 
 set (INC inc)
 
-add_library(bad-zapple ${SOURCES})
+add_library(bad-zapple SHARED ${SOURCES})
 
 target_include_directories(bad-zapple PUBLIC ${INC})
 
 #---------------------------------------------------------------------------------------#
 
 # Install Catch2
-set(CMAKE_PREFIX_PATH ${CUSTOM_LIB_PATH}/lib/cmake/Catch2 ${CMAKE_PREFIX_PATH})
-find_package(Catch2 QUIET)
-if (NOT Ccatch2_FOUND)
-	message(STATUS "YourLibrary not found. Attempting to install...")
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan "Running installation script..."
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/install_catch.sh
-        RESULT_VARIABLE install_result
-    )
-    if(NOT install_result EQUAL 0)
-        message(FATAL_ERROR "Failed to install YourLibrary. Please install it manually.")
-    endif()
+#set(CMAKE_PREFIX_PATH ${CUSTOM_LIB_PATH}/lib/cmake/Catch2 ${CMAKE_PREFIX_PATH})
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE("inc/catch.hpp" CATCH_FOUND)
+if (NOT CATCH_FOUND)
+	execute_process(
+		COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan "Curling catch.hpp"
+		COMMAND mkdir lib
+		COMMAND curl https://raw.githubusercontent.com/catchorg/Catch2/v2.x/single_include/catch2/catch.hpp -o lib/catch.hpp
+		RESULT_VARIABLE install_result
+	)
 endif()
+include(build/tests_sources.cmake)
+add_executable(tests ${TEST_SOURCES})
+target_link_libraries(tests PUBLIC bad-zapple)
+target_include_directories(tests PRIVATE lib)
 
 #---------------------------------------------------------------------------------------#
 
 # Use the library in the test project
 
-find_package(Catch2 REQUIRED)
-include(build/tests_sources.cmake)
-add_executable(tests ${TEST_SOURCES})
-target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
-target_link_libraries(tests PUBLIC bad-zapple)
+#include(build/tests_sources.cmake)
+#add_executable(tests ${TEST_SOURCES} inc/catch.hpp)
+#target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
+#target_link_libraries(tests PUBLIC bad-zapple)
 
 #---------------------------------------------------------------------------------------#

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 NAME=bad-zapple
 BUILD_DIR=./build
 TARGET=$(BUILD_DIR)/$(NAME).a
+CMAKEFILE=$(BUILD_DIR)/Makefile
 
-all: 
+from-0-to-test: all
+	make run-test
+
+all: $(CMAKEFILE)
 	make -C $(BUILD_DIR) $(NAME)
 
 .PHONY: all 
 
-$(TARGET): 
+$(TARGET): $(CMAKEFILE)
 	make -C $(BUILD_DIR) $(NAME)
-
-$(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
 
 clean:
 	make clean -C $(NAME)
@@ -23,31 +24,32 @@ fclean:
 
 .PHONY: fclean 
 
-update-cmake: update-sources
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(CMAKEFILE) : bld
+
+bld: update-sources
 	cmake -B $(BUILD_DIR)
 
-.PHONY: update-cmake
+.PHONY: bld
 
 update-sources: $(BUILD_DIR)
 	@sh ./tools/list_sources.sh build/sources.cmake
 
 .PHONY: update-sources 
 
-re: clean all
-
-.PHONY: re
-
 lsp: update-sources
 	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B $(BUILD_DIR)
 
 .PHONY: lsp 
 
-tests:
+tests: 
 	make -C build/ tests
 
 .PHONY: tests 
 
-test-run: tests
+run-test: tests
 	./build/tests
 
 .PHONY: test-run

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,13 @@ lsp: update-sources
 	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B $(BUILD_DIR)
 
 .PHONY: lsp 
+
+tests:
+	make -C build/ tests
+
+.PHONY: tests 
+
+test-run: tests
+	./build/tests
+
+.PHONY: test-run

--- a/inc/dummy.hpp
+++ b/inc/dummy.hpp
@@ -1,0 +1,1 @@
+int dummy(void);

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int dummy(void) {
+	std::cout << "i'm a dummy." << std::endl;
+	return 0;
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,9 @@
+#include <catch2/catch_test_macros.hpp>
+#include "dummy.hpp"
+
+
+
+TEST_CASE( "Dummy is tested", "[dummy]") {
+	REQUIRE( dummy() == 0);
+	REQUIRE( dummy() != 1);
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,6 +1,7 @@
-#include <catch2/catch_test_macros.hpp>
+#include <catch.hpp>
 #include "dummy.hpp"
 
+#define CATCH_CONFIG_MAIN
 
 
 TEST_CASE( "Dummy is tested", "[dummy]") {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,7 +1,7 @@
+#define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 #include "dummy.hpp"
 
-#define CATCH_CONFIG_MAIN
 
 
 TEST_CASE( "Dummy is tested", "[dummy]") {

--- a/tools/install_catch.sh
+++ b/tools/install_catch.sh
@@ -1,0 +1,7 @@
+mkdir -p ~/lib/;
+mkdir -p ~/goinfre/
+
+
+git clone https://github.com/catchorg/Catch2.git ~/goinfre/Catch2;
+cmake -B ~/goinfre/Catch2/build -S ~/goinfre/Catch2 -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=~/lib
+cmake --build ~/goinfre/Catch2/build/ --target install 

--- a/tools/list_sources.sh
+++ b/tools/list_sources.sh
@@ -1,7 +1,14 @@
-echo listing sources in $1
-echo sources found:
-echo set\(SOURCES > $1
-find src/ -name *.cpp | sed 's/^/\t/' | tee -a $1
-find src/ -name *.hpp | sed 's/^/\t/' | tee -a $1
-find src/ -name *.h | sed 's/^/\t/' | tee -a $1
-echo \) >> $1
+echo listing sources build/lib_sources.cmake;
+echo sources found:;
+echo set\(SOURCES > build/lib_sources.cmake;
+find src/ -name '*.cpp' | sed 's/^/\t/' | tee -a build/lib_sources.cmake;
+find src/ -name '*.hpp' | sed 's/^/\t/' | tee -a build/lib_sources.cmake;
+find src/ -name '*.h' | sed 's/^/\t/' | tee -a build/lib_sources.cmake;
+echo \) >> build/lib_sources.cmake;
+
+echo listing test sources in build/tests_sources.cmake;
+echo set\(TEST_SOURCES > build/tests_sources.cmake;
+find tests/ -name '*.cpp' | sed 's/^/\t/' | tee -a build/tests_sources.cmake;
+find tests/ -name '*.hpp' | sed 's/^/\t/' | tee -a build/tests_sources.cmake;
+find tests/ -name '*.h' | sed 's/^/\t/' | tee -a build/tests_sources.cmake;
+echo \) >> build/tests_sources.cmake;


### PR DESCRIPTION
Add of a tests directory allowing us to put all file with .cpp .h or .hpp extension in the tests binary.

This binary is our test binary. it compiles with bad-zapple lib.

install catch2 script is launched when the install is not detected. If it isn't it creates a lib directory and a goinfre in $HOME and build the lib in goinfre to put it in lib.

